### PR TITLE
Refactor documentation links and update README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
     - uses: actions/checkout@v5
       with:
         lfs: true        
+    
+    - name: Docs Link Lint
+      shell: pwsh
+      run: |
+        pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/check-doc-links.ps1
         
     - name: Generate Workfloew revsion
       shell: pwsh

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 John Ludlow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# MonoGame TerrainGeneration2D
+
+[![Build and Test](https://github.com/JohnLudlow/MonoGameSamples.TerrainGeneration2D/actions/workflows/main.yml/badge.svg)](https://github.com/JohnLudlow/MonoGameSamples.TerrainGeneration2D/actions/workflows/main.yml)
+![.NET Version](https://img.shields.io/badge/.NET-10.0-blue)
+![MonoGame](https://img.shields.io/badge/MonoGame-DesktopGL-orange)
+[![License](https://img.shields.io/github/license/JohnLudlow/MonoGameSamples.TerrainGeneration2D)](https://github.com/JohnLudlow/MonoGameSamples.TerrainGeneration2D)
+
+This repository contains a 2D terrain generation sample built with MonoGame, featuring chunked tilemaps, heightmaps, and Wave Function Collapse.
+
+## Tech Stack & Versions
+- .NET: 10.0
+- MonoGame (DesktopGL): 3.8.5 (runtime: app/benchmarks), 3.8.4.1 (tests)
+- Gum.MonoGame: 2025.12.9.1
+
+## Features
+- Chunked tilemap (64×64 chunks) with save/load (gzipped) per chunk
+- Deterministic generation with WFC + heightmap fallback
+- Camera pan/zoom, tooltip, and debug overlay (F12)
+- EventSource-based diagnostics and optional benchmarks
+
+## Getting Started
+Prerequisites
+- .NET 10 SDK
+
+Build
+```pwsh
+dotnet build TerrainGeneration2D.slnx
+```
+
+Run
+```pwsh
+dotnet run --project TerrainGeneration2D/TerrainGeneration2D.csproj
+```
+
+Test
+```pwsh
+dotnet test TerrainGeneration2D.Tests/TerrainGeneration2D.Tests.csproj
+```
+
+Docs
+- See the index at docs/README.md
+
+## Roadmap
+- Heuristics: optional Shannon entropy and influence tie-breaks
+- Backtracking: deeper stats and candidate ordering refinements
+- Seam constraints between chunks for stricter continuity
+- Live UI to tweak weights and regenerate visible chunks
+
+## Troubleshooting
+- Content not updating after asset changes: re-run a full solution build to rebuild the Content pipeline.
+- Blank window or GL errors: update GPU drivers; ensure DesktopGL dependencies are installed.
+- Missing saves/regeneration: delete TerrainGeneration2D.Core/Content/saves to force new generation.
+- Debug overlay not visible: toggle with F12 (see GameController bindings).
+
+## CI & Quality
+- GitHub Actions builds and runs tests on push/PR (Windows).
+- Docs link lint runs in CI to prevent broken in-repo links.
+
+## License
+This project is licensed under the MIT License. See LICENSE for details.
+
+- Start with the docs index: docs/README.md
+- Build: `dotnet build TerrainGeneration2D.slnx`
+- Run: `dotnet run --project TerrainGeneration2D/TerrainGeneration2D.csproj`
+- Test: `dotnet test TerrainGeneration2D.Tests/TerrainGeneration2D.Tests.csproj`

--- a/TerrainGeneration2D.Core/Diagnostics/GamePerformanceEventSource.cs
+++ b/TerrainGeneration2D.Core/Diagnostics/GamePerformanceEventSource.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.Tracing;
+
+namespace JohnLudlow.MonoGameSamples.TerrainGeneration2D.Core.Diagnostics;
+
+[EventSource(Name = "MyGame.Performance")]
+public sealed class GamePerformanceEventSource : EventSource
+{
+  public static readonly GamePerformanceEventSource Log = new();
+
+  private readonly EventCounter _fps;
+
+  private GamePerformanceEventSource()
+  {
+    _fps = new EventCounter("fps", this)
+    {
+      DisplayName = "Frames Per Second",
+      DisplayUnits = "fps"
+    };
+  }
+
+  public void ReportFps(float framesPerSecond)
+  {
+    _fps.WriteMetric(framesPerSecond);
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,10 @@
 # Docs Index
 
+[![Build and Test](https://github.com/JohnLudlow/MonoGameSamples.TerrainGeneration2D/actions/workflows/main.yml/badge.svg)](https://github.com/JohnLudlow/MonoGameSamples.TerrainGeneration2D/actions/workflows/main.yml)
+![.NET Version](https://img.shields.io/badge/.NET-10.0-blue)
+![MonoGame](https://img.shields.io/badge/MonoGame-DesktopGL-orange)
+[![License](https://img.shields.io/github/license/JohnLudlow/MonoGameSamples.TerrainGeneration2D)](https://github.com/JohnLudlow/MonoGameSamples.TerrainGeneration2D)
+
 Welcome to the documentation index. Key entries:
 
 - Map Generation wiki: [docs/map-generation/README.md](map-generation/README.md)

--- a/docs/map-generation-tutorial.md
+++ b/docs/map-generation-tutorial.md
@@ -3,7 +3,7 @@
 This guide reproduces the entire terrain map generation experience and explains how the chunks, height maps, and Wave Function Collapse stages fit together. Follow each numbered step to go from zero to a live, instrumented 2048×2048 tile map.
 
 1. **Refresh the build/content pipeline.**
-   - Run `dotnet build TerrainGeneration2D.slnx` to compile every project, re-run the Gum/asset builder, and populate `TerrainGeneration2D.Content/bin/Debug/net10.0/Content`. The command shown in [docs/architecture-class-diagram.md](docs/architecture-class-diagram.md#L1-L26) is the canonical starting point for any change that touches art, audio, or UI definitions.
+   - Run `dotnet build TerrainGeneration2D.slnx` to compile every project, re-run the Gum/asset builder, and populate `TerrainGeneration2D.Content/bin/Debug/net10.0/Content`. The command shown in [architecture-class-diagram.md](architecture-class-diagram.md#L1-L26) is the canonical starting point for any change that touches art, audio, or UI definitions.
 
 2. **Understand the core loop that drives the map.**
    - Read the architecture diagram and the `Core`/scene plumbing so you know why only one scene lives at a time and why `GameScene.Initialize` clears `GumService.Default.Root` before recreating the UI.
@@ -14,10 +14,10 @@ This guide reproduces the entire terrain map generation experience and explains 
    - As soon as the camera moves, `GameScene.Update` forwards input through `GameController` helpers and calls `ChunkedTilemap.UpdateActiveChunks`, which keeps a 3×3 buffered window of chunks around the viewport.
 
 4. **Follow how each chunk is born, cached, and saved.**
-   - Open [TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs](TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs) to see the deterministic seed (`masterSeed + chunkX * 73856093 + chunkY * 19349663`), the gzipped save format (`Content/saves/map_{chunkX}_{chunkY}.dat`), and the `GenerateChunk` path.
+   - Open [TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs](../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs) to see the deterministic seed (`masterSeed + chunkX * 73856093 + chunkY * 19349663`), the gzipped save format (`Content/saves/map_{chunkX}_{chunkY}.dat`), and the `GenerateChunk` path.
    - When `useWaveFunctionCollapse` is true (default), the chunk calls `WfcProvider.Generate`; when WFC succeeds it copies the tile grid into the chunk, otherwise it falls back to `GenerateRandomChunk`, which samples `HeightMapGenerator` and maps heights via `TerrainRuleConfiguration`.
-   - Inspect [`TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs`](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs) to see how candidate tiles are constrained based on nearby decisions, weighted by neighbor matches, and then propagated through the `TileTypeRegistry` rules.
-   - The WFC constraints depend on the tile types defined in [`TerrainGeneration2D.Core/Mapping/TileTypes/TileTypes.cs`](TerrainGeneration2D.Core/Mapping/TileTypes/TileTypes.cs) and the threshold-driven materials described in [`TerrainGeneration2D.Core/Mapping/TileTypes/TerrainRuleConfiguration.cs`](TerrainGeneration2D.Core/Mapping/TileTypes/TerrainRuleConfiguration.cs).
+   - Inspect [`TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs`](../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs) to see how candidate tiles are constrained based on nearby decisions, weighted by neighbor matches, and then propagated through the `TileTypeRegistry` rules.
+   - The WFC constraints depend on the tile types defined in [`TerrainGeneration2D.Core/Mapping/TileTypes/TileTypes.cs`](../TerrainGeneration2D.Core/Mapping/TileTypes/TileTypes.cs) and the threshold-driven materials described in [`TerrainGeneration2D.Core/Mapping/TileTypes/TerrainRuleConfiguration.cs`](../TerrainGeneration2D.Core/Mapping/TileTypes/TerrainRuleConfiguration.cs).
 
 5. **Use the debug overlay to visualize active and dirty chunks.**
    - Press F12 (handled by `GameController.ToggleDebugOverlay`) to toggle the overlay drawn after the chunk rendering stage. The overlay copies `ChunkedTilemap.GetActiveChunkInfos` snapshots and draws rectangles for the buffered 3×3 range plus the viewport (see `TerrainGeneration2D/Scenes/GameScene.cs` for the debug draw helpers and the white/green boundary logic).
@@ -32,7 +32,7 @@ This guide reproduces the entire terrain map generation experience and explains 
    - For rapid iterations, consider exposing a Gum control that rebuilds the `ChunkedTilemap`: dispose the old instance, call `SaveAll`, delete the cached saves if needed, and construct a fresh tilemap with the updated configs.
 
 8. **Observe the instrumentation that proves chunk work is happening.**
-   - The DEBUG build already enables `Core.EnablePerformanceDiagnostics`, so the console prints the `TerrainPerformanceEventSource` events defined under `TerrainGeneration2D.Core/Diagnostics`. You can follow the step-by-step capture instructions in [docs/performance-and-debugging.md](docs/performance-and-debugging.md#L1-L62) to monitor the `active-chunk-count`/`chunks-saved-per-second` counters via `dotnet-counters` and to record `dotnet-trace` captures.
+   - The DEBUG build already enables `Core.EnablePerformanceDiagnostics`, so the console prints the `TerrainPerformanceEventSource` events defined under `TerrainGeneration2D.Core/Diagnostics`. You can follow the step-by-step capture instructions in [performance-and-debugging.md](performance-and-debugging.md#L1-L62) to monitor the `active-chunk-count`/`chunks-saved-per-second` counters via `dotnet-counters` and to record `dotnet-trace` captures.
 
 9. **Stretch goal: add a new tile type or rule.**
    - Add a new `TileType` implementation under `TerrainGeneration2D.Core/Mapping/TileTypes`, register it via `TileTypeRegistry.CreateDefault`, and ensure it exposes the evaluation logic you want (neighbor checks, height-based gating, group metrics via `MappingInformationService`). Then run steps 3–7 again to confirm the new tile participates in WFC and chunk saves.

--- a/docs/map-generation/README.md
+++ b/docs/map-generation/README.md
@@ -9,7 +9,7 @@ Scope:
 
 Key code:
 - [TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs](../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs)
-- [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs)
+- [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 - [TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs)
 
 Sub-wikis:

--- a/docs/map-generation/wfc/01-overview.md
+++ b/docs/map-generation/wfc/01-overview.md
@@ -42,7 +42,7 @@ private bool Generate(int maxIterations = 10000)
 ```
 
 Code references:
-- Algorithm: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs)
+- Algorithm: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 - Integration: [TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs](../../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs)
 
 Navigation

--- a/docs/map-generation/wfc/02-domains.md
+++ b/docs/map-generation/wfc/02-domains.md
@@ -46,8 +46,8 @@ Rule checks compute whether a candidate tile is compatible with a neighbor, give
 
 These inputs are packaged into a `TileRuleContext` passed to rule evaluators during propagation.
 
-Code references:
-- Data + setup: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs)
+- Code references:
+- Data + setup: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 - Rule evaluation: [TerrainGeneration2D.Core/Mapping/TileAdjacencyRules.cs](../../../TerrainGeneration2D.Core/Mapping/TileAdjacencyRules.cs)
 
 Navigation

--- a/docs/map-generation/wfc/03-propagation.md
+++ b/docs/map-generation/wfc/03-propagation.md
@@ -66,7 +66,7 @@ private bool ConstrainNeighbor(int x, int y, Direction dirToNeighbor, int neighb
 
 Code references:
 - Selection + loop: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
-- Neighbor constraints: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse.cs)
+- Neighbor constraints: [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 
 Navigation
 - Up: [WFC README](README.md)

--- a/docs/map-generation/wfc/05-heuristics.md
+++ b/docs/map-generation/wfc/05-heuristics.md
@@ -13,7 +13,7 @@ Purpose: describe how the solver chooses the next cell to collapse and which til
 - Shannon entropy option: compute $H = -\sum p_i \log p_i$ using tile priors for richer selection. Cells with higher information gain can be prioritized.
 - Most Constrained + Most Constraining: after selecting the most constrained cell, prefer ones that impact many neighbors (e.g., near boundaries) to stabilize propagation.
 - Tie-breaking:
-  - Runtime: break equal-entropy ties via the injected randomness provider; see [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
+  - Runtime: break equal-entropy ties via the injected randomness provider; see [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
   - Deterministic tests: inject a deterministic provider to ensure reproducible tie-breaking.
   - Current flags (runtime-configurable):
     - `Heuristics.UseMostConstrainingTieBreak`: prefer cells that influence more undecided neighbors.
@@ -131,7 +131,7 @@ Rendered diagrams (for non-Mermaid renderers):
 ![Weighted vs uniform probabilities](../../assets/heuristics-weighted-bars.svg)
 
 ### Sample: Lowest-Entropy Selection and Tie-Breaking
-Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
+Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 
 ```csharp
 // Picks the cell with the smallest domain (fewest candidates).
@@ -180,7 +180,7 @@ private (int x, int y) FindLowestEntropy()
  - Backtracking linkage: this ordering is consumed by the decision frames in backtracking to explore candidates deterministically; see [04 — Backtracking](04-backtracking.md).
 
 ### Sample: Weighted Collapse (Non-Backtracking)
-Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
+Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 
 ```csharp
 // Compute neighbor-match boost and perform a weighted roll
@@ -219,7 +219,7 @@ private bool CollapseCell(int x, int y)
 ```
 
 ### Sample: Candidate Ordering (Backtracking)
-Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
+Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 
 ```csharp
 // Order candidates by weight desc, then tile id asc for deterministic exploration
@@ -237,12 +237,12 @@ stack.Push(frame);
 
 ## Determinism & Randomness Provider
 
-- Abstraction: `IRandomProvider` decouples randomness from the algorithm. See [RandomProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/RandomProvider.cs).
+- Abstraction: `IRandomProvider` decouples randomness from the algorithm. See [RandomProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/RandomProvider.cs).
 - Adapter: `RandomAdapter` wraps `System.Random` for runtime.
-- Tests: implement a deterministic provider that returns fixed values to make choices predictable. Example in [TerrainGeneration2D.Tests/MappingTests.cs](../../TerrainGeneration2D.Tests/MappingTests.cs).
+- Tests: implement a deterministic provider that returns fixed values to make choices predictable. Example in [TerrainGeneration2D.Tests/MappingTests.cs](../../../TerrainGeneration2D.Tests/MappingTests.cs).
 
 ### Sample: Deterministic Provider and Injection
-Project: TerrainGeneration2D.Tests, file: [MappingTests.cs](../../TerrainGeneration2D.Tests/MappingTests.cs)
+Project: TerrainGeneration2D.Tests, file: [MappingTests.cs](../../../TerrainGeneration2D.Tests/MappingTests.cs)
 
 ```csharp
 // Deterministic IRandomProvider for reproducible choices in tests
@@ -260,7 +260,7 @@ var success = wfc.Generate(enableBacktracking: true, maxIterations: 10000, maxBa
 ```
 
 ### Sample: Mixed Strategy (Heuristic + Uniform)
-Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
+Project: TerrainGeneration2D.Core, file: [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
 
 ```csharp
 // Blend heuristic weighting with uniform randomness to retain variation
@@ -292,17 +292,17 @@ int ChooseTile(List<(int tile, int weight)> weightedOptions)
 - Entropy selection: lowest domain size; ties resolved via `IRandomProvider`.
 - Non-backtracking collapse: weighted roll using neighbor-match boost; candidate list sorted by tile id to avoid HashSet nondeterminism.
 - Backtracking: candidates ordered by weight desc, then tile id asc; changes recorded via `ChangeLog` to support rollback.
-- Files: [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs), [ChangeLog.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/ChangeLog.cs).
+- Files: [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs), [ChangeLog.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/ChangeLog.cs).
 
 ## Diagnostics
 
 - Use `TerrainPerformanceEventSource` to track WFC phases and stats: decisions, contradictions, backtracks, max depth.
 - Validate heuristic changes by inspecting `WfcStats` and toggling the debug overlay.
-- File: [TerrainPerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs).
+- File: [TerrainPerformanceEventSource.cs](../../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs).
 
 ## Integration
 
-- Runtime: `ChunkedTilemap` constructs `WfcProvider` per chunk; backtracking enabled with sane limits. See [ChunkedTilemap.cs](../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs).
+- Runtime: `ChunkedTilemap` constructs `WfcProvider` per chunk; backtracking enabled with sane limits. See [ChunkedTilemap.cs](../../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs).
 - Tuning knobs: adjust backtracking limits alongside weight multipliers to balance performance and stability.
 
 ## Try It
@@ -316,11 +316,11 @@ int ChooseTile(List<(int tile, int weight)> weightedOptions)
 
 ## Implementation Notes
 
-- Non-backtracking collapse: uses neighbor-match weighted selection in [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs) and stabilizes candidate ordering with a tile-id sort to avoid HashSet nondeterminism.
-- Backtracking loop: orders candidates by weight desc then tile id asc, captures them in `DecisionFrame`, and records reversible mutations via [ChangeLog.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/ChangeLog.cs); contradictions trigger rollback and alternate candidate exploration.
-- Randomness provider: `IRandomProvider` methods (`NextInt`, `NextDouble`) are consumed throughout selection; runtime uses [RandomAdapter](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/RandomProvider.cs), tests inject deterministic providers.
-- Diagnostics: decision/contradiction/rollback events emitted via [TerrainPerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs) help tune weights and backtracking limits.
-- Integration: chunks construct `WfcProvider` per chunk and pass backtracking limits; see [ChunkedTilemap.cs](../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs).
+- Non-backtracking collapse: uses neighbor-match weighted selection in [WfcProvider.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs) and stabilizes candidate ordering with a tile-id sort to avoid HashSet nondeterminism.
+- Backtracking loop: orders candidates by weight desc then tile id asc, captures them in `DecisionFrame`, and records reversible mutations via [ChangeLog.cs](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/ChangeLog.cs); contradictions trigger rollback and alternate candidate exploration.
+- Randomness provider: `IRandomProvider` methods (`NextInt`, `NextDouble`) are consumed throughout selection; runtime uses [RandomAdapter](../../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/RandomProvider.cs), tests inject deterministic providers.
+- Diagnostics: decision/contradiction/rollback events emitted via [TerrainPerformanceEventSource.cs](../../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs) help tune weights and backtracking limits.
+- Integration: chunks construct `WfcProvider` per chunk and pass backtracking limits; see [ChunkedTilemap.cs](../../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs).
 
 ## Navigation
 - Up: [WFC README](README.md)

--- a/docs/performance-and-debugging.md
+++ b/docs/performance-and-debugging.md
@@ -14,7 +14,7 @@
 + After the trace completes, run `dotnet-trace ps` (or the task manager) to verify the process ID and reopen the trace if needed; you can also replay the timeline with `perfview /trace:terrain-events.nettrace` or `speedscope terrain-events.speedscope.json` if you convert the file.
 
 ## Benchmark extension
-- The benchmark suite in [TerrainGeneration2D.Benchmarks/Program.cs](TerrainGeneration2D.Benchmarks/Program.cs) now exposes parameterized scenarios:
+- The benchmark suite in [TerrainGeneration2D.Benchmarks/Program.cs](../TerrainGeneration2D.Benchmarks/Program.cs) now exposes parameterized scenarios:
 	- Map sizes: 512, 1024, 2048 tiles per side
 	- Entropy strategy: Domain, Shannon, Combined (Domain+Shannon with tie-break)
 	- WFC time budget per chunk: 20ms, 50ms, 100ms

--- a/docs/terrain2d-tutorial/01-setup.md
+++ b/docs/terrain2d-tutorial/01-setup.md
@@ -363,5 +363,5 @@ You should see your asset (e.g., verify.txt or your image) under the game's Cont
 - If the project fails to restore, confirm the package reference and internet access.
 
 ## See also
-- Next phase: [02 — Single tile](docs/terrain2d-tutorial/02-single-tile.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Next phase: [02 — Single tile](02-single-tile.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/02-single-tile.md
+++ b/docs/terrain2d-tutorial/02-single-tile.md
@@ -379,6 +379,6 @@ dotnet run --project src/TerrainGeneration2D/TerrainGeneration2D.csproj
 You should see the screen filled with the first tile from your atlas.
 
 See also:
-- Previous phase: [01 — Setup](docs/terrain2d-tutorial/01-setup.md)
-- Next steps with deterministic random fill in [docs/terrain2d-tutorial/05-random-tiles.md](docs/terrain2d-tutorial/05-random-tiles.md).
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md).
+- Previous phase: [01 — Setup](01-setup.md)
+- Next steps with deterministic random fill in [05-random-tiles.md](05-random-tiles.md).
+- Tutorial index: [README.md](README.md).

--- a/docs/terrain2d-tutorial/03-logging.md
+++ b/docs/terrain2d-tutorial/03-logging.md
@@ -248,6 +248,6 @@ Notes:
 - Route errors to a telemetry pipeline (Seq, OpenTelemetry).
 
 See also:
-- Previous phase: [02 — Single tile](docs/terrain2d-tutorial/02-single-tile.md)
-- Next phase: [04 — Performance](docs/terrain2d-tutorial/04-performance.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [02 — Single tile](02-single-tile.md)
+- Next phase: [04 — Performance](04-performance.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/04-performance.md
+++ b/docs/terrain2d-tutorial/04-performance.md
@@ -102,7 +102,7 @@ You will see `fps` reported once per second.
 - Counters are emitted when listeners pass `EventCounterIntervalSec` in `EnableEvents`.
 
 ## 5. Try It
-- Create the file shown in [TerrainGeneration2D.Core/Diagnostics/GamePerformanceEventSource.cs](TerrainGeneration2D.Core/Diagnostics/GamePerformanceEventSource.cs) and add the `Draw()` snippet in your game class to report FPS.
+- Create the file shown in [TerrainGeneration2D.Core/Diagnostics/GamePerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/GamePerformanceEventSource.cs) and add the `Draw()` snippet in your game class to report FPS.
 - Build and run the game:
 ```pwsh
 dotnet build src/Terrain2D.sln
@@ -136,6 +136,6 @@ Notes:
 - Full listener tests require an `EventListener` and are integration-level; here we only assert that reporting a counter does not throw.
 
 ## See also
-- Previous phase: [03 — Logging](docs/terrain2d-tutorial/03-logging.md)
-- Next phase: [05 — Random tiles](docs/terrain2d-tutorial/05-random-tiles.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [03 — Logging](03-logging.md)
+- Next phase: [05 — Random tiles](05-random-tiles.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/05-random-tiles.md
+++ b/docs/terrain2d-tutorial/05-random-tiles.md
@@ -153,12 +153,12 @@ protected override void Draw(GameTime gameTime)
 }
 ```
 
-Note: For a `TextureRegion` overview and `Tileset` setup, see Phase 02 — Implement TextureRegion in [docs/terrain2d-tutorial/02-single-tile.md](docs/terrain2d-tutorial/02-single-tile.md).
+Note: For a `TextureRegion` overview and `Tileset` setup, see Phase 02 — Implement TextureRegion in [02-single-tile.md](02-single-tile.md).
 
 ## See also
-- Previous phase: [04 — Performance](docs/terrain2d-tutorial/04-performance.md)
-- Next phase: [06 — Adjacency rules](docs/terrain2d-tutorial/06-adjacency-rules.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [04 — Performance](04-performance.md)
+- Next phase: [06 — Adjacency rules](06-adjacency-rules.md)
+- Tutorial index: [README.md](README.md)
 
 Run:
 ```bash

--- a/docs/terrain2d-tutorial/06-adjacency-rules.md
+++ b/docs/terrain2d-tutorial/06-adjacency-rules.md
@@ -284,6 +284,6 @@ Run the game and look for edge consistency. Tweak tile IDs, rule parameters, and
 - In the next phase we’ll introduce heightmaps to drive tile selection and further constrain options.
 
 ## See also
-- Previous phase: [05 — Random tiles](docs/terrain2d-tutorial/05-random-tiles.md)
-- Next phase: [07 — Heightmap rules](docs/terrain2d-tutorial/07-heightmap.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [05 — Random tiles](05-random-tiles.md)
+- Next phase: [07 — Heightmap rules](07-heightmap.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/07-heightmap.md
+++ b/docs/terrain2d-tutorial/07-heightmap.md
@@ -129,6 +129,6 @@ Run the game—you’ll see continents, shorelines, forests, mountains, and snow
 After choosing a biome, you can still apply the simple neighbor rule from phase 06 to reduce harsh borders.
 
 ## See also
-- Previous phase: [06 — Adjacency rules](docs/terrain2d-tutorial/06-adjacency-rules.md)
-- Next phase: [08 — WFC Domains & Entropy](docs/terrain2d-tutorial/08-wfc-domains.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [06 — Adjacency rules](06-adjacency-rules.md)
+- Next phase: [08 — WFC Domains & Entropy](08-wfc-domains.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/08-wfc-domains.md
+++ b/docs/terrain2d-tutorial/08-wfc-domains.md
@@ -67,6 +67,6 @@ public sealed class WfcEngine
 Proceed to propagation in the next phase.
 
 ## See also
-- Previous phase: [07 — Heightmap rules](docs/terrain2d-tutorial/07-heightmap.md)
-- Next phase: [09 — WFC Propagation](docs/terrain2d-tutorial/09-wfc-propagation.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [07 — Heightmap rules](07-heightmap.md)
+- Next phase: [09 — WFC Propagation](09-wfc-propagation.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/09-wfc-propagation.md
+++ b/docs/terrain2d-tutorial/09-wfc-propagation.md
@@ -88,14 +88,14 @@ Proceed to backtracking in the next phase.
 - Tie-breaking: resolve equal-entropy cells via an injected randomness provider for stability in production, and a deterministic provider in tests.
 - Weights: when choosing a tile for a cell, favor neighbors of the same type with a simple boost (e.g., `1 + k * matches`). Keep candidate ordering stable (sort by tile id) to avoid nondeterminism.
 - Determinism: use `IRandomProvider` to control randomness in unit tests and sort candidates to eliminate HashSet iteration variability.
-- Tuning: start with small multipliers; monitor contradictions/backtracks via diagnostics and adjust. See the deeper discussion in [docs/wfc/wfc-implementation-roadmap.md](docs/wfc/wfc-implementation-roadmap.md) and implementation in [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
+- Tuning: start with small multipliers; monitor contradictions/backtracks via diagnostics and adjust. See the deeper discussion in [wfc-implementation-roadmap.md](../wfc/wfc-implementation-roadmap.md) and implementation in [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
 
 > Try It
 >
-> - Deterministic tests: implement a test-only `IRandomProvider` that returns fixed values and pass it to `WfcProvider` to make collapse choices predictable. See the example in [TerrainGeneration2D.Tests/MappingTests.cs](TerrainGeneration2D.Tests/MappingTests.cs).
+> - Deterministic tests: implement a test-only `IRandomProvider` that returns fixed values and pass it to `WfcProvider` to make collapse choices predictable. See the example in [TerrainGeneration2D.Tests/MappingTests.cs](../../TerrainGeneration2D.Tests/MappingTests.cs).
 > - Runtime tuning idea: add a config value (e.g., `WfcWeights.NeighborMatchBoost`) in appsettings and thread it into `WfcProvider` to scale the neighbor-match multiplier. Start small (e.g., 1–3) and observe contradictions/backtracks via diagnostics.
 
 ## See also
-- Previous phase: [08 — WFC Domains & Entropy](docs/terrain2d-tutorial/08-wfc-domains.md)
-- Next phase: [10 — WFC Backtracking](docs/terrain2d-tutorial/10-wfc-backtracking.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [08 — WFC Domains & Entropy](08-wfc-domains.md)
+- Next phase: [10 — WFC Backtracking](10-wfc-backtracking.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/10-wfc-backtracking.md
+++ b/docs/terrain2d-tutorial/10-wfc-backtracking.md
@@ -98,7 +98,7 @@ Proceed to integration in the next phase.
 - Candidate ordering: in backtracking, order by weight descending (e.g., neighbor-match boost) then tile id ascending to keep exploration deterministic.
 - Weights: tune the neighbor-match multiplier conservatively to reduce contradictions without causing streaking; consider context-aware boosts (heightmap/biome).
 - Tuning with limits: balance `maxBacktrackSteps` and `maxDepth` with heuristic aggressiveness—strong locality reduces branching but can increase rollback pressure.
-- References: see [docs/wfc/wfc-implementation-roadmap.md](docs/wfc/wfc-implementation-roadmap.md) and implementation in [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
+- References: see [wfc-implementation-roadmap.md](../wfc/wfc-implementation-roadmap.md) and implementation in [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
 
 > Try It
 >
@@ -106,6 +106,6 @@ Proceed to integration in the next phase.
 > - Runtime tuning idea: expose `WfcWeights` (e.g., `Base`, `NeighborMatchBoost`) via config and adjust alongside `maxBacktrackSteps`/`maxDepth`. Track `WfcStats` to see how changes affect backtracks and max depth.
 
 ## See also
-- Previous phase: [09 — WFC Propagation](docs/terrain2d-tutorial/09-wfc-propagation.md)
-- Next phase: [11 — WFC Integration](docs/terrain2d-tutorial/11-wfc-integration.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [09 — WFC Propagation](09-wfc-propagation.md)
+- Next phase: [11 — WFC Integration](11-wfc-integration.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/11-wfc-integration.md
+++ b/docs/terrain2d-tutorial/11-wfc-integration.md
@@ -36,6 +36,6 @@ public class WfcIntegrationTests
 This completes WFC integration.
 
 ## See also
-- Previous phase: [10 — WFC Backtracking](docs/terrain2d-tutorial/10-wfc-backtracking.md)
-- Earlier phases: [08 — Domains](docs/terrain2d-tutorial/08-wfc-domains.md), [09 — Propagation](docs/terrain2d-tutorial/09-wfc-propagation.md)
-- Tutorial index: [docs/terrain2d-tutorial/README.md](docs/terrain2d-tutorial/README.md)
+- Previous phase: [10 — WFC Backtracking](10-wfc-backtracking.md)
+- Earlier phases: [08 — Domains](08-wfc-domains.md), [09 — Propagation](09-wfc-propagation.md)
+- Tutorial index: [README.md](README.md)

--- a/docs/terrain2d-tutorial/12-config-wfc-weights.md
+++ b/docs/terrain2d-tutorial/12-config-wfc-weights.md
@@ -63,7 +63,7 @@ These values are passed to `HeightMapGenerator` to shape the overall terrain.
 
 ## Applying Changes
 - The config is read when `GameScene` constructs the tilemap. Restart the game to apply changes.
-- To observe a full regeneration, delete the saves folder: [TerrainGeneration2D.Core/Content/saves](../../TerrainGeneration2D.Core/Content/saves). Chunks will be re-generated with the new weights.
+- To observe a full regeneration, delete the saves folder at TerrainGeneration2D.Core/Content/saves. Chunks will be re-generated with the new weights.
 
 ## Try It
 - Make selection neutral to neighbors: set `NeighborMatchBoost` to `0` and restart.

--- a/docs/wfc/wfc-implementation-roadmap.md
+++ b/docs/wfc/wfc-implementation-roadmap.md
@@ -13,10 +13,10 @@
 - Tests: Comprehensive unit tests pass; tutorials aligned with APIs.
 
 Key files:
-- [TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs](TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs)
-- [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
-- [TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs](TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs)
-- [TerrainGeneration2D/GameController.cs](TerrainGeneration2D/GameController.cs)
+- [TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs](../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs)
+- [TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)
+- [TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs)
+- [TerrainGeneration2D/GameController.cs](../../TerrainGeneration2D/GameController.cs)
 
 ## WFC Evaluation (Current Algorithm)
 - Domains: Each cell tracks a `HashSet<int>` of candidate tiles initialized from `TileTypeRegistry.ValidTileIds`.
@@ -45,7 +45,7 @@ Conclusion: This is a partial WFC implementation (observation + propagation) but
 - Add decision stack with `(x,y, candidates, index)`.
 - Snapshot domains or maintain an undo log to revert changes cheaply.
 - On contradiction, pop and try next candidate; terminate when all collapsed or no candidates remain.
-- File: update [WfcProvider.cs](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
+- File: update [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
 
 2. Entropy & Selection Heuristics
 - Entropy metric:
@@ -53,7 +53,7 @@ Conclusion: This is a partial WFC implementation (observation + propagation) but
   - Option: Shannon entropy $H = -\sum p_i \log p_i$ using tile priors/weights to prefer cells with higher information gain.
   - Hybrid: Most Constrained (lowest entropy) + Most Constraining (highest impact on neighbors) for improved stability.
 - Tie-breaking strategy:
-  - Current: random among equal-entropy cells using `IRandomProvider` (see [WfcProvider.cs](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)).
+  - Current: random among equal-entropy cells using `IRandomProvider` (see [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs)).
   - Deterministic mode: for testability, keep candidate ordering stable and inject a deterministic provider.
   - Alternatives: bias ties by screen/world position (e.g., top-left to bottom-right), Perlin noise, or distance to chunk center.
 - Weight strategies (tile choice within a cell):
@@ -66,10 +66,10 @@ Conclusion: This is a partial WFC implementation (observation + propagation) but
   - Avoid HashSet iteration nondeterminism by ordering before any selection; document tie-breakers explicitly.
 - Practical tuning tips:
   - Start with small multipliers; increase only if contradictions persist or visuals look too noisy.
-  - Monitor `wfc_contradictions`, `wfc_backtracks`, and `wfc_stats` via [TerrainPerformanceEventSource.cs](TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs); adjust weights to reduce rollback pressure.
+  - Monitor `wfc_contradictions`, `wfc_backtracks`, and `wfc_stats` via [TerrainPerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs); adjust weights to reduce rollback pressure.
   - Balance `maxBacktrackSteps` and `maxDepth` with heuristic aggressiveness; strong locality weights reduce branching but may raise contradiction hotspots.
   - Use the debug overlay to visually inspect collapse patterns; consider an entropy heatmap to identify problem areas.
- - See also: [05 — Heuristics](docs/map-generation/wfc/05-heuristics.md) for a focused deep-dive and "Try It" tips.
+ - See also: [05 — Heuristics](../map-generation/wfc/05-heuristics.md) for a focused deep-dive and "Try It" tips.
 
 3. Rule Tables & AC-3 Propagation
 - Precompute adjacency tables: `allowed[(tile, dir)] = {neighbors}` from `TileTypeRegistry`.
@@ -80,7 +80,7 @@ Conclusion: This is a partial WFC implementation (observation + propagation) but
 - Seed WFC domains at chunk edges from already-generated neighbor chunks.
 - When generating chunk `(cx,cy)`, import boundary constraints from `(cx-1,cy)`, `(cx,cy-1)`, etc.
 - Ensure persistence maintains seam constraints; handle regeneration coherently.
-- Files: [ChunkedTilemap.cs](TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs) and [WfcProvider.cs](TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
+- Files: [ChunkedTilemap.cs](../../TerrainGeneration2D.Core/Graphics/ChunkedTilemap.cs) and [WfcProvider.cs](../../TerrainGeneration2D.Core/Mapping/WaveFunctionCollapse/WfcProvider.cs).
 
 5. Heightmap Integration
 - Cache `IHeightProvider` samples per chunk to avoid repeated calls.
@@ -89,7 +89,7 @@ Conclusion: This is a partial WFC implementation (observation + propagation) but
 6. Performance & Diagnostics
 - Add counters: `wfc_observations`, `wfc_propagations`, `wfc_backtracks`, `wfc_contradictions`.
 - Add timings per chunk for observation/propagation/backtracking phases.
-- Files: [TerrainPerformanceEventSource.cs](TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs).
+- Files: [TerrainPerformanceEventSource.cs](../../TerrainGeneration2D.Core/Diagnostics/TerrainPerformanceEventSource.cs).
 
 7. Tests (TDD)
 - Domain initialization and entropy correctness.

--- a/scripts/check-doc-links.ps1
+++ b/scripts/check-doc-links.ps1
@@ -1,0 +1,76 @@
+param(
+  [string]$DocsPath = "docs"
+)
+
+# Lints markdown links in the docs folder to ensure they don't escape the repo root
+# and they don't use absolute local paths. Exits with non-zero code on violations.
+
+$repoRoot = (Get-Location).Path
+$errors = @()
+
+# Gather markdown files
+$mdFiles = Get-ChildItem -Path $DocsPath -Filter *.md -Recurse -ErrorAction Stop
+
+foreach ($file in $mdFiles) {
+  $lines = Get-Content -LiteralPath $file.FullName
+  for ($i = 0; $i -lt $lines.Count; $i++) {
+    $line = $lines[$i]
+    $matches = [regex]::Matches($line, "\[.*?\]\((.*?)\)")
+    foreach ($m in $matches) {
+      $target = $m.Groups[1].Value
+
+      # Allow external links
+      if ($target -match "^(https?://|mailto:)") { continue }
+
+      # Disallow absolute local paths and root-anchored paths
+      if ($target -match "^[A-Za-z]:\\") {
+        $errors += @{ File = $file.FullName; Line = $i + 1; Issue = "Absolute local path"; Target = $target }
+        continue
+      }
+      if ($target -match "^/") {
+        $errors += @{ File = $file.FullName; Line = $i + 1; Issue = "Root-anchored path"; Target = $target }
+        continue
+      }
+      if ($target -match "^(file|vscode)://") {
+        $errors += @{ File = $file.FullName; Line = $i + 1; Issue = "Unsupported URI scheme"; Target = $target }
+        continue
+      }
+
+      # Guard against escaping repo root via too many ../ segments
+      if ($target -match "^(\.\./){4,}") {
+        $errors += @{ File = $file.FullName; Line = $i + 1; Issue = "Path escapes repo root"; Target = $target }
+        continue
+      }
+
+      # Strip fragment and query for existence check
+      $pathOnly = $target.Split('#')[0].Split('?')[0]
+      # Normalize slashes for Windows filesystem check
+      $pathFs = $pathOnly -replace "/", "\\"
+
+      try {
+        $abs = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($file.DirectoryName, $pathFs))
+      } catch {
+        $abs = $null
+      }
+
+      if ($abs -and $abs.StartsWith($repoRoot)) {
+        # Check existence for local relative links only
+        if (-not (Test-Path -LiteralPath $abs)) {
+          $errors += @{ File = $file.FullName; Line = $i + 1; Issue = "Missing target"; Target = $target }
+        }
+      } elseif ($abs) {
+        $errors += @{ File = $file.FullName; Line = $i + 1; Issue = "Resolved outside repo"; Target = $target }
+      }
+    }
+  }
+}
+
+if ($errors.Count -gt 0) {
+  Write-Host "Docs link check found $($errors.Count) issue(s):" -ForegroundColor Red
+  foreach ($e in $errors) {
+    Write-Host " - $($e.File):$($e.Line) -> $($e.Issue): $($e.Target)"
+  }
+  exit 1
+} else {
+  Write-Host "Docs link check passed: no invalid links." -ForegroundColor Green
+}


### PR DESCRIPTION
- Updated links in map generation documentation to point to the new WfcProvider.cs file.
- Adjusted navigation links in terrain tutorial documentation for consistency and clarity.
- Added LICENSE file with MIT License text.
- Created README.md with project overview, tech stack, features, getting started instructions, and troubleshooting tips.
- Implemented a PowerShell script to check for broken links in documentation.
- Added GamePerformanceEventSource class for performance diagnostics.